### PR TITLE
Docker push when pushing on master

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -1,5 +1,8 @@
 name: Build and push to AWS ECR on schedule
 on:
+  push:
+    branches:
+      - master
   schedule:
     - cron: "0 12 * * 3"
 


### PR DESCRIPTION
CI only runs on a schedule for the moment, I think it's a good idea to run it when pushing to `master` as well