### PR TITLE
Upgrade docker rust image 1.39 -> 1.75

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN wget -O "GeoLite2-City.tar.gz" "https://download.maxmind.com/app/geoip_downl
 RUN tar -xzvf GeoLite2-City*.tar.gz
  
 # Rust compile container
-FROM rust:1.39 as build
+FROM rust:1.75 as build
 
 RUN rustup target add x86_64-unknown-linux-musl
 


### PR DESCRIPTION
# Summary | Résumé

Latest PR caused the build to fail, as the dependencies do not align with the Rust version installed in the Docker image. Hence this PR is set to upgrade the Rust version as well (which I should have done in previous PR).

```
#20 [build 8/8] RUN cargo build --release --target x86_64-unknown-linux-musl
#20 0.231     Updating crates.io index
#20 94.77 error: failed to select a version for the requirement `hyper = "= 1.1.0"`
#20 94.77   candidate versions found which didn't match: 0.14.28, 0.14.27, 0.14.26, ...
#20 94.77   location searched: crates.io index
#20 94.77 required by package `ipv4-geolocate-webservice v0.2.0 (/ipv4-geolocate-webservice)`
#20 ERROR: process "/bin/sh -c cargo build --release --target x86_64-unknown-linux-musl" did not complete successfully: exit code: 101
```

I ran the Docker build image locally with the new Rust increase and it worked.

# Test instructions | Instructions pour tester la modification

You can run the `docker build .` command locally if you want to test as well.