### PR TITLE
Added kubectl rollout restart commands for AWS EKS dev,staging,prod

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   deploy:
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     name: Build and push
     steps:

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -10,6 +10,7 @@ on:
 env:
   DOCKER_ORG: public.ecr.aws/cds-snc
   DOCKER_SLUG: public.ecr.aws/cds-snc/notify-ipv4-geolocate-webservice
+  KUBECTL_VERSION: '1.25.4'
 
 permissions:
   id-token: write
@@ -31,7 +32,7 @@ jobs:
     - name: Configure credentials to CDS public ECR using OIDC
       uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
       with:
-        role-to-assume: arn:aws:iam::283582579564:role/ipv4-geolocate-webservice-apply
+        role-to-assume: arn:aws:iam::283582579564:role/ 
         role-session-name: Ipv4GeolocateWebserviceGitHubActions
         aws-region: "us-east-1"
   
@@ -44,6 +45,48 @@ jobs:
     - name: Build
       run: |
         docker build --build-arg LICENSE_KEY=${{ secrets.LICENSE_KEY }} -t $DOCKER_SLUG:`date '+%Y-%m-%d'` -t $DOCKER_SLUG:latest .
+
     - name: Publish
       run: |
         docker push $DOCKER_SLUG:latest && docker push $DOCKER_SLUG:`date '+%Y-%m-%d'`
+
+    - name: Install kubectl
+      run: |
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/v$KUBECTL_VERSION/bin/linux/amd64/kubectl
+        chmod +x ./kubectl
+        sudo mv ./kubectl /usr/local/bin/kubectl
+        kubectl version --client
+        mkdir -p $HOME/.kube
+
+    - name: Configure credentials to Notify dev EKS using OIDC
+      uses: aws-actions/configure-aws-credentials@master
+      with:
+        role-to-assume: arn:aws:iam::800095993820:role/ipv4-geolocate-webservice-apply
+        role-session-name: Ipv4GeolocateWebserviceGitHubActions
+        aws-region: "ca-central-1"
+
+    - name: Restart ipv4 deployment in dev environment
+      run: |
+        kubectl rollout restart deployment/ipv4 -n notification-canada-ca
+
+    - name: Configure credentials to Notify staging EKS using OIDC
+      uses: aws-actions/configure-aws-credentials@master
+      with:
+        role-to-assume: arn:aws:iam::239043911459:role/ipv4-geolocate-webservice-apply
+        role-session-name: Ipv4GeolocateWebserviceGitHubActions
+        aws-region: "ca-central-1"
+
+    - name: Restart ipv4 deployment in staging environment
+      run: |
+        kubectl rollout restart deployment/ipv4 -n notification-canada-ca
+
+    - name: Configure credentials to Notify production EKS using OIDC
+      uses: aws-actions/configure-aws-credentials@master
+      with:
+        role-to-assume: arn:aws:iam::296255494825:role/ipv4-geolocate-webservice-apply
+        role-session-name: Ipv4GeolocateWebserviceGitHubActions
+        aws-region: "ca-central-1"
+
+    - name: Restart ipv4 deployment in production environment
+      run: |
+        kubectl rollout restart deployment/ipv4 -n notification-canada-ca


### PR DESCRIPTION
# Blockers for this PR

Wait for this PR prior to merge this one:
https://github.com/cds-snc/aft-account-request/pull/162

This will create the necessary OIDC roles within each GCNotify AWS accounts for dev, staging and production. We need to confirm what's the names of these roles then with the changes contained in this PR.

Wait for this PR prior to merge this one:
https://github.com/cds-snc/notification-manifests/pull/2298

This will provide necessary permissions to the previously created OIDC roles within kubernetes to allow this repository to perform `kubectl rollout restart...` commands.

# Summary | Résumé

End goal is to perform a `kubectl rollout restart...` after the ipv4-geolocate-webservice image has been pushed to the public cds-snc ECR for all AWS environment accounts (dev, staging and production.

* Added kubectl rollout restart commands for AWS EKS dev,staging,prod.

# Test instructions | Instructions pour tester la modification

🤞 