### PR TITLE
Replaced rollout call with the manifests rollout script for staging env

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -51,58 +51,16 @@ jobs:
       run: |
         docker push $DOCKER_SLUG:latest && docker push $DOCKER_SLUG:`date '+%Y-%m-%d'`
 
-    - name: Install kubectl
-      run: |
-        curl -LO https://storage.googleapis.com/kubernetes-release/release/v$KUBECTL_VERSION/bin/linux/amd64/kubectl
-        chmod +x ./kubectl
-        sudo mv ./kubectl /usr/local/bin/kubectl
-        kubectl version --client
-        mkdir -p $HOME/.kube
-
-    - name: Configure credentials to Notify dev EKS using OIDC
-      uses: aws-actions/configure-aws-credentials@master
-      with:
-        role-to-assume: arn:aws:iam::800095993820:role/ipv4-geolocate-webservice-apply
-        role-session-name: Ipv4GeolocateWebserviceGitHubActions
-        aws-region: "ca-central-1"
-
-    - name: Install DEV Kubernetes configuration
-      run: |
-        aws eks --region $AWS_REGION update-kubeconfig --name notification-canada-ca-dev-eks-cluster --alias dev --kubeconfig $HOME/.kube/config
-        kubectl config use-context dev
-
-    - name: Restart ipv4 deployment in dev environment
-      run: |
-        kubectl rollout restart deployment/ipv4 -n notification-canada-ca
-
-    - name: Configure credentials to Notify staging EKS using OIDC
-      uses: aws-actions/configure-aws-credentials@master
-      with:
-        role-to-assume: arn:aws:iam::239043911459:role/ipv4-geolocate-webservice-apply
-        role-session-name: Ipv4GeolocateWebserviceGitHubActions
-        aws-region: "ca-central-1"
-
-    - name: Install staging Kubernetes configuration
-      run: |
-        aws eks --region $AWS_REGION update-kubeconfig --name notification-canada-ca-staging-eks-cluster --alias staging --kubeconfig $HOME/.kube/config
-        kubectl config use-context staging
+    # DEV won't be supported for the time being until we have a working CI/CD in that env.
+    # - name: Restart ipv4 deployment in dev environment
+    #   run: |
+    #     ./scripts/callManifestsRollout.sh ${GITHUB_SHA::7}
 
     - name: Restart ipv4 deployment in staging environment
       run: |
-        kubectl rollout restart deployment/ipv4 -n notification-canada-ca
-
-    - name: Configure credentials to Notify production EKS using OIDC
-      uses: aws-actions/configure-aws-credentials@master
-      with:
-        role-to-assume: arn:aws:iam::296255494825:role/ipv4-geolocate-webservice-apply
-        role-session-name: Ipv4GeolocateWebserviceGitHubActions
-        aws-region: "ca-central-1"
-
-    - name: Install production Kubernetes configuration
-      run: |
-        aws eks --region $AWS_REGION update-kubeconfig --name notification-canada-ca-production-eks-cluster --alias prod --kubeconfig $HOME/.kube/config
-        kubectl config use-context prod
-
-    - name: Restart ipv4 deployment in production environment
-      run: |
-        kubectl rollout restart deployment/ipv4 -n notification-canada-ca
+        ./scripts/callManifestsRollout.sh ${GITHUB_SHA::7}
+    
+    # TODO: To be fixed, broken at the moment.
+    # - name: Restart ipv4 deployment in production environment
+    #   run: |
+    #     ./scripts/callManifestsRollout.sh ${GITHUB_SHA::7}

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -11,6 +11,7 @@ env:
   DOCKER_ORG: public.ecr.aws/cds-snc
   DOCKER_SLUG: public.ecr.aws/cds-snc/notify-ipv4-geolocate-webservice
   KUBECTL_VERSION: '1.25.4'
+  WORKFLOW_PAT: ${{ secrets.WORKFLOW_GITHUB_PAT }}
 
 permissions:
   id-token: write

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   deploy:
-    if: ${{ github.ref == 'refs/heads/main' }}
+    #if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     name: Build and push
     steps:

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   deploy:
-    #if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     name: Build and push
     steps:

--- a/scripts/callManifestsRollout.sh
+++ b/scripts/callManifestsRollout.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+GITHUB_SHA=$1
+PAYLOAD="{\"ref\":\"main\",\"inputs\":{\"docker_sha\":\"$GITHUB_SHA\"}}"
+
+RESPONSE=$(curl -w '%{http_code}\n' \
+  -o /dev/null -s \
+  -L -X POST -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $WORKFLOW_PAT" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/repos/cds-snc/notification-manifests/actions/workflows/ipv4-geolocate-webservice-staging.yaml/dispatches \
+  -d "$PAYLOAD")
+
+if [ "$RESPONSE" != 204 ]; then
+  echo "ERROR CALLING MANIFESTS ROLLOUT: HTTP RESPONSE: $RESPONSE"
+  exit 1
+fi


### PR DESCRIPTION
# Summary | Résumé

Migrating the Kubernetes rollout from a direct API call to the ARC runners dispatch.

# Test instructions | Instructions pour tester la modification

Run the workflow and 🤞 
