### PR TITLE
Added support for release_tag parameter

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -11,6 +11,7 @@ env:
   DOCKER_ORG: public.ecr.aws/cds-snc
   DOCKER_SLUG: public.ecr.aws/cds-snc/notify-ipv4-geolocate-webservice
   KUBECTL_VERSION: '1.25.4'
+  RELEASE_TAG: `date '+%Y-%m-%d'`
   WORKFLOW_PAT: ${{ secrets.WORKFLOW_GITHUB_PAT }}
 
 permissions:
@@ -46,7 +47,7 @@ jobs:
 
     - name: Build
       run: |
-        docker build --build-arg LICENSE_KEY=${{ secrets.LICENSE_KEY }} -t $DOCKER_SLUG:`date '+%Y-%m-%d'` -t $DOCKER_SLUG:latest .
+        docker build --build-arg LICENSE_KEY=${{ secrets.LICENSE_KEY }} -t $DOCKER_SLUG:$RELEASE_TAG -t $DOCKER_SLUG:latest .
 
     - name: Publish
       run: |
@@ -59,7 +60,7 @@ jobs:
 
     - name: Restart ipv4 deployment in staging environment
       run: |
-        ./scripts/callManifestsRollout.sh ${GITHUB_SHA::7}
+        ./scripts/callManifestsRollout.sh ${GITHUB_SHA::7} $RELEASE_TAG
     
     # TODO: To be fixed, broken at the moment.
     # - name: Restart ipv4 deployment in production environment

--- a/scripts/callManifestsRollout.sh
+++ b/scripts/callManifestsRollout.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
+
+# Parameters that need to be passed in:
 GITHUB_SHA=$1
-PAYLOAD="{\"ref\":\"main\",\"inputs\":{\"docker_sha\":\"$GITHUB_SHA\"}}"
+RELEASE_TAG=$2
+
+# Check if the required parameters are passed in
+if [ -z "$GITHUB_SHA" ]; then
+  echo "ERROR: GITHUB_SHA is not set"
+  exit 1
+fi
+
+if [ -z "$RELEASE_TAG" ]; then
+  echo "ERROR: RELEASE_TAG is not set"
+  exit 1
+fi
+
+PAYLOAD="{\"ref\":\"main\",\"inputs\":{\"docker_sha\":\"$GITHUB_SHA\",\"release_tag\":\"$RELEASE_TAG\"}}"
 
 RESPONSE=$(curl -w '%{http_code}\n' \
   -o /dev/null -s \


### PR DESCRIPTION
# Summary | Résumé

Because the ipv4 image has a date suffix instead of the traditional github sha ID (there is one release per day), send the release tag parameter (today's date) to the github action dispatch call who can then reference to the proper kubernetes image reference within Kubernetes.

# Test instructions | Instructions pour tester la modification

We'll have to run this workflow. 