### PR TITLE
Remove the git sha ID parameter for the GitHub action workflow

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -63,7 +63,7 @@ jobs:
 
     - name: Restart ipv4 deployment in staging environment
       run: |
-        ./scripts/callManifestsRollout.sh ${GITHUB_SHA::7} $RELEASE_TAG
+        ./scripts/callManifestsRollout.sh $RELEASE_TAG
     
     # TODO: To be fixed, broken at the moment.
     # - name: Restart ipv4 deployment in production environment

--- a/scripts/callManifestsRollout.sh
+++ b/scripts/callManifestsRollout.sh
@@ -1,21 +1,14 @@
 #!/bin/bash
 
 # Parameters that need to be passed in:
-GITHUB_SHA=$1
-RELEASE_TAG=$2
-
-# Check if the required parameters are passed in
-if [ -z "$GITHUB_SHA" ]; then
-  echo "ERROR: GITHUB_SHA is not set"
-  exit 1
-fi
+RELEASE_TAG=$1
 
 if [ -z "$RELEASE_TAG" ]; then
   echo "ERROR: RELEASE_TAG is not set"
   exit 1
 fi
 
-PAYLOAD="{\"ref\":\"main\",\"inputs\":{\"docker_sha\":\"$GITHUB_SHA\",\"release_tag\":\"$RELEASE_TAG\"}}"
+PAYLOAD="{\"ref\":\"main\",\"inputs\":{\"release_tag\":\"$RELEASE_TAG\"}}"
 
 RESPONSE=$(curl -w '%{http_code}\n' \
   -o /dev/null -s \


### PR DESCRIPTION
# Summary | Résumé

* Remove unnecessary parameter to the ipv4 rollout github workflow dispatch. The release tag parameter which contains today's date will replace it. 

# Test instructions | Instructions pour tester la modification

Run the workflow in staging.
