### PR TITLE
vpn staging

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -12,6 +12,7 @@ env:
   DOCKER_SLUG: public.ecr.aws/cds-snc/notify-ipv4-geolocate-webservice
   KUBECTL_VERSION: '1.25.4'
   WORKFLOW_PAT: ${{ secrets.WORKFLOW_GITHUB_PAT }}
+  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
 permissions:
   id-token: write
@@ -56,15 +57,44 @@ jobs:
       run: |
         docker push $DOCKER_SLUG:latest && docker push $DOCKER_SLUG:`date '+%Y-%m-%d'`
 
-    # DEV won't be supported for the time being until we have a working CI/CD in that env.
-    # - name: Restart ipv4 deployment in dev environment
-    #   run: |
-    #     ./scripts/callManifestsRollout.sh ${GITHUB_SHA::7}
+    - name: Configure credentials to Notify account using OIDC
+      uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+      with:
+        role-to-assume: arn:aws:iam::239043911459:role/notification-document-download-api-apply
+        role-session-name: NotifyDocumentDownloadApiGitHubActions
+        aws-region: "ca-central-1"
 
-    - name: Restart ipv4 deployment in staging environment
+    - name: Install OpenVPN
       run: |
-        ./scripts/callManifestsRollout.sh $RELEASE_TAG
-    
+        sudo apt update
+        sudo apt install -y openvpn openvpn-systemd-resolved
+
+    - name: Install 1Pass CLI
+      run: |
+        curl -o 1pass.deb https://downloads.1password.com/linux/debian/amd64/stable/1password-cli-amd64-latest.deb
+        sudo dpkg -i 1pass.deb
+
+    - name: One Password Fetch
+      run: |
+        op read op://4eyyuwddp6w4vxlabrr2i2duxm/"Staging Github Actions VPN"/notesPlain > /var/tmp/staging.ovpn
+
+    - name: Connect to VPN
+      uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5"
+      with:
+        config_file: /var/tmp/staging.ovpn
+        client_key: ${{ secrets.STAGING_OVPN_CLIENT_KEY }}
+        echo_config: false       
+        
+    - name: Get Kubernetes configuration
+      run: |
+        aws eks --region $AWS_REGION update-kubeconfig --name notification-canada-ca-staging-eks-cluster --kubeconfig $HOME/.kube/config
+
+    - name: Update image in staging
+      run: |
+        kubectl set image deployment.apps/ipv4 ipv4=$DOCKER_SLUG:$RELEASE_TAG -n=notification-canada-ca --kubeconfig=$HOME/.kube/config
+
+
+
     # TODO: To be fixed, broken at the moment.
     # - name: Restart ipv4 deployment in production environment
     #   run: |


### PR DESCRIPTION
# Summary | Résumé

Moving away from Github ARC and instead using a VPN to connect to K8s to deploy Documentation.

# Test instructions | Instructions pour tester la modification

Docker build/push/deploy works and the new image is deployed to staging.